### PR TITLE
Make feed process use the timer library

### DIFF
--- a/code/tick/feed.q
+++ b/code/tick/feed.q
@@ -84,4 +84,4 @@ init:{
 h:.servers.gethandlebytype[`tickerplant;`any]
 
 init 0
-.z.ts:feed
+.timer.repeat[.proc.cp[];0Wp;0D00:00:00.200;(`feed;`);"Publish Feed"];


### PR DESCRIPTION
Suggested fix on the data publisher so that it uses timer.q in TorQ rather than overwriting .z.ts which causes problems in some TorQ processes. 