### PR TITLE
Torq missing sym check

### DIFF
--- a/code/checks/email.txt
+++ b/code/checks/email.txt
@@ -1,0 +1,1 @@
+james.burrows@aquaq.co.uk 

--- a/code/checks/symcheck.q
+++ b/code/checks/symcheck.q
@@ -1,0 +1,84 @@
+//This script runs on a cronjob every five minutes.
+//It checks all 4 rdb tables for the last time by sym
+//It then compares the (current time - tm1 minutes) to the current time
+//Syms appearing in the initital rdb check but not in this tm1-minute window
+//are flagged, appended to log
+//Cron then reads this and sends mail only if it has records (mail -Es)
+
+//Manual Usage Example
+/q symcheck.q -rdb ::14002:admin:admin -init 0 -noexit 1 -tm1 00:05:00.000
+
+//create dictionary of cmdargs to type, connect to rdb, exit if not specified or can't find rdb
+prse:`rdb`init`noexit`tm1!"SBBT";
+
+o:{[x]a:.Q.opt[.z.x]; prse[d]$(d:(key prse) inter (key a))#first each a}[];
+if[any not `rdb`init`noexit`tm1 in key .Q.opt[.z.x];exit 0];
+
+rdb:@[hopen;first hsym o[`rdb];{-1 "rdb unavailable"}];
+if[rdb<0;exit 0];
+
+//get list tables to check, and syms to expect (per table)
+tablist:`quote`trade`trade_iex`quote_iex;
+symlistbs:`AIG`HPQ`AMD`IBM`DOW`INTC`DELL`MSFT`GOOG`AAPL;
+symlistiex:`CAT`DOG;
+
+//set upsert table for last value per sym
+symtab:([sym:`$();tab:`$()]time:`timestamp$());
+
+//define sym grab function
+//connects to rdb and grabs last record by sym,table
+symgrab:{[x]
+  {
+  grab:{[x]select last time by sym,tab:"s"$x from x};
+  data:rdb(grab;x);
+  `symtab upsert data;
+  }each tablist;
+ };
+
+//checks for regular (non iex) syms, compares them to original list and flags missings
+symsnotpresentreg:{[o]
+  regsyms::select last time by sym from symtab where tab in `quote`trade;
+  reglist::(exec distinct sym from regsyms) except exec distinct sym from symtab where time within(.z.P-o`tm1;.z.P),tab in`quote`trade;
+  regdata::`sym xkey select sym,last_time:time from select from `time xasc symtab where sym in reglist,tab in `quote`trade;
+ };
+
+
+//checks for iex syms
+symsnotpresentiex:{[o]
+  iexsyms::select last time by sym from symtab where tab in `quote_iex`trade_iex;
+  iexlist::(exec distinct sym from iexsyms) except exec distinct sym from symtab where time within(.z.P-o`tm1;.z.P), tab in `quote_iex`trade_iex;
+  iexdata::`sym xkey select sym,last_time:time from select from `time xasc symtab where sym in iexlist,tab in `quote_iex`trade_iex;
+ };
+
+createlog:{
+  logfile:`$":logs/","missingsyms.log";
+  fh::hopen logfile;
+ };
+
+symlog:{[f;x]
+  neg[fh](string[.z.P]," ; ",raze string[f]," ; ",x);
+ };
+
+logsyms:{ 
+  symgrab[x];
+ };
+
+appendmissing:{[]
+  if[0<count iexdata;symlog[`logsyms;string [exec distinct sym from iexdata], " ; last seen at: ",raze string exec last last_time from iexdata]];
+  if[0<count regdata;symlog[`logsyms;string [exec distinct sym from regdata], " ; last seen at: ",raze string exec last last_time from regdata]];
+  exit 0;
+ };
+
+//initialization function
+
+init:{[o]
+  createlog[];
+  logsyms[];
+  symsnotpresentreg[o];
+  symsnotpresentiex[o];
+  system "t ",string o[`timer];
+  $[(0<count iexdata)|0<count regdata;appendmissing[];exit 0];
+ };
+
+if[o`init;init[o]];
+if[not`noexit in key .Q.opt .z.x;exit 0];

--- a/code/checks/symcheckmailer.sh
+++ b/code/checks/symcheckmailer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#crontab usage
+#*/5 * * * 1-5 . /home/jburrows/proddev/TorQ-Finance-Starter-Pack/code/checks/symcheckmailer.sh
+
+#cd into directory to load files and log dest
+cd "/home/jburrows/proddev/TorQ-Finance-Starter-Pack/code/checks/"
+
+#set email var
+EMAIL="james.burrows@aquaq.co.uk"
+
+#set rdb port and tm check
+rdb="::13402:admin:admin"
+tm1="00:05:00.000"
+
+#create empty logfile to mail, -Es sends mail if file has content
+touch logs/missingsyms.log
+
+#set q vars and rlwrap executable to launch, with cmdline args
+QLIC=/opt/kdb/QLIC QHOME=/opt/kdb/3.5/2017.11.30 rlwrap -r /opt/kdb/3.5/2017.11.30/l64/q symcheck.q -rdb $rdb -init 1 -noexit 1 -tm1 $tm1 | mail -Es "Missing Syms Detected!" $EMAIL < /home/jburrows/prodsupport2/TorQ-Finance-Starter-Pack/code/checks/logs/missingsyms.log
+
+#If file is there, remove it once mail sent
+if [ `ls /home/jburrows/proddev/TorQ-Finance-Starter-Pack/code/checks/logs/ | wc -l` -gt 0 ]; then
+  rm logs/missingsyms.log
+fi

--- a/code/checks/symcheckmailer.sh
+++ b/code/checks/symcheckmailer.sh
@@ -18,7 +18,7 @@ touch logs/missingsyms.log
 #set q vars and rlwrap executable to launch, with cmdline args
 QLIC=/opt/kdb/QLIC QHOME=/opt/kdb/3.5/2017.11.30 rlwrap -r /opt/kdb/3.5/2017.11.30/l64/q symcheck.q -rdb $rdb -init 1 -noexit 1 -tm1 $tm1 | mail -Es "Missing Syms Detected!" $EMAIL < /home/jburrows/prodsupport2/TorQ-Finance-Starter-Pack/code/checks/logs/missingsyms.log
 
-#If file is there, remove it once mail sent
+#If file is there then remove it once mail sent
 if [ `ls /home/jburrows/proddev/TorQ-Finance-Starter-Pack/code/checks/logs/ | wc -l` -gt 0 ]; then
   rm logs/missingsyms.log
 fi


### PR DESCRIPTION
The following files are to be used together, symcheck.q will query the configurable rdb port for the last time by each sym in each table. It will then compare this time to the most recent time within 'current time - tm1' where tm1 is configurable. Syms appearing in the initial check, but not in the most recent window will be flagged and appended to a logfile.

The symcheckmailer.sh script should run on a crontab (example provided in script). It will check the logfile for records, only mailing if it contains data. If it does, the records of the logfile will be emailed to the provided users alerting them of what sym is missing, at what time the check occured, and the last time of appearance of that sym.

email.txt is a configurable text file of users to be emailed in the event of a missing sym(s).