### PR TITLE
[WIP] Integrating Monit for monitoring TorQ

### DIFF
--- a/appconfig/process.csv
+++ b/appconfig/process.csv
@@ -1,21 +1,21 @@
 host,port,proctype,procname,U,localtime,g,T,w,load,startwithall,extras,qcmd
-localhost,{KDBBASEPORT}+1,discovery,discovery1,appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/discovery.q,1,,q
-localhost,{KDBBASEPORT},tickerplant,tickerplant1,appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/tickerplant.q,1,-schemafile database -tplogdir ${TORQHOME}/hdb,q
-localhost,{KDBBASEPORT}+2,rdb,rdb1,appconfig/passwords/accesslist.txt,1,1,3,,${KDBCODE}/processes/rdb.q,1,,q
-localhost,{KDBBASEPORT}+3,hdb,hdb1,appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
-localhost,{KDBBASEPORT}+4,hdb,hdb2,appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
-localhost,{KDBBASEPORT}+5,wdb,wdb1,appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
-localhost,{KDBBASEPORT}+6,sort,sort1,appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,-s -2,q
-localhost,{KDBBASEPORT}+7,gateway,gateway1,appconfig/passwords/accesslist.txt,1,1,,4000,${KDBCODE}/processes/gateway.q,1,,q
+localhost,{KDBBASEPORT}+1,discovery,discovery1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/discovery.q,1,,q
+localhost,{KDBBASEPORT},tickerplant,tickerplant1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/tickerplant.q,1,-schemafile ${BASEDIR}/database -tplogdir ${BASEDIR}/hdb,q
+localhost,{KDBBASEPORT}+2,rdb,rdb1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,3,,${KDBCODE}/processes/rdb.q,1,,q
+localhost,{KDBBASEPORT}+3,hdb,hdb1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
+localhost,{KDBBASEPORT}+4,hdb,hdb2,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
+localhost,{KDBBASEPORT}+5,wdb,wdb1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
+localhost,{KDBBASEPORT}+6,sort,sort1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,-s -2,q
+localhost,{KDBBASEPORT}+7,gateway,gateway1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,4000,${KDBCODE}/processes/gateway.q,1,,q
 localhost,{KDBBASEPORT}+8,kill,killtick,,1,0,,,${KDBCODE}/processes/kill.q,0,,q
 localhost,{KDBBASEPORT}+9,monitor,monitor1,,1,0,,,${KDBCODE}/processes/monitor.q,1,,q
 localhost,{KDBBASEPORT}+10,tickerlogreplay,tpreplay1,,1,0,,,,0,,q
-localhost,{KDBBASEPORT}+11,housekeeping,housekeeping1,appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/housekeeping.q,1,,q
-localhost,{KDBBASEPORT}+12,reporter,reporter1,appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/reporter.q,1,,q
+localhost,{KDBBASEPORT}+11,housekeeping,housekeeping1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/housekeeping.q,1,,q
+localhost,{KDBBASEPORT}+12,reporter,reporter1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/reporter.q,1,,q
 localhost,{KDBBASEPORT}+13,compression,compression1,,1,0,,,${KDBCODE}/processes/compression.q,1,,q
 localhost,{KDBBASEPORT}+14,feed,feed1,,1,0,,,${KDBAPPCODE}/tick/feed.q,1,,q
-localhost,{KDBBASEPORT}+15,chainedtp,chainedtp1,appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/chainedtp.q,1,,q
+localhost,{KDBBASEPORT}+15,chainedtp,chainedtp1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/chainedtp.q,1,,q
 localhost,{KDBBASEPORT}+16,sortslave,sortslave1,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
 localhost,{KDBBASEPORT}+17,sortslave,sortslave2,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
-localhost,{KDBBASEPORT}+18,metrics,metrics1,appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/metrics.q,1,,q
+localhost,{KDBBASEPORT}+18,metrics,metrics1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/metrics.q,1,,q
 localhost,{KDBBASEPORT}+19,iexfeed,iexfeed1,,1,0,,,${KDBCODE}/processes/iexfeed.q,1,,q

--- a/appconfig/process.csv
+++ b/appconfig/process.csv
@@ -1,21 +1,21 @@
 host,port,proctype,procname,U,localtime,g,T,w,load,startwithall,extras,qcmd
-localhost,{KDBBASEPORT}+1,discovery,discovery1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/discovery.q,1,,q
-localhost,{KDBBASEPORT},tickerplant,tickerplant1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/tickerplant.q,1,-schemafile ${BASEDIR}/database -tplogdir ${BASEDIR}/hdb,q
-localhost,{KDBBASEPORT}+2,rdb,rdb1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,3,,${KDBCODE}/processes/rdb.q,1,,q
-localhost,{KDBBASEPORT}+3,hdb,hdb1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
-localhost,{KDBBASEPORT}+4,hdb,hdb2,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
-localhost,{KDBBASEPORT}+5,wdb,wdb1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
-localhost,{KDBBASEPORT}+6,sort,sort1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,-s -2,q
-localhost,{KDBBASEPORT}+7,gateway,gateway1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,4000,${KDBCODE}/processes/gateway.q,1,,q
+localhost,{KDBBASEPORT}+1,discovery,discovery1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/discovery.q,1,,q
+localhost,{KDBBASEPORT},tickerplant,tickerplant1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/tickerplant.q,1,-schemafile ${TORQHOME}/database -tplogdir ${TORQHOME}/hdb,q
+localhost,{KDBBASEPORT}+2,rdb,rdb1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,3,,${KDBCODE}/processes/rdb.q,1,,q
+localhost,{KDBBASEPORT}+3,hdb,hdb1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
+localhost,{KDBBASEPORT}+4,hdb,hdb2,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,60,4000,${KDBHDB},1,,q
+localhost,{KDBBASEPORT}+5,wdb,wdb1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
+localhost,{KDBBASEPORT}+6,sort,sort1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/wdb.q,1,-s -2,q
+localhost,{KDBBASEPORT}+7,gateway,gateway1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,,4000,${KDBCODE}/processes/gateway.q,1,,q
 localhost,{KDBBASEPORT}+8,kill,killtick,,1,0,,,${KDBCODE}/processes/kill.q,0,,q
 localhost,{KDBBASEPORT}+9,monitor,monitor1,,1,0,,,${KDBCODE}/processes/monitor.q,1,,q
 localhost,{KDBBASEPORT}+10,tickerlogreplay,tpreplay1,,1,0,,,,0,,q
-localhost,{KDBBASEPORT}+11,housekeeping,housekeeping1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/housekeeping.q,1,,q
-localhost,{KDBBASEPORT}+12,reporter,reporter1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/reporter.q,1,,q
+localhost,{KDBBASEPORT}+11,housekeeping,housekeeping1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/housekeeping.q,1,,q
+localhost,{KDBBASEPORT}+12,reporter,reporter1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/reporter.q,1,,q
 localhost,{KDBBASEPORT}+13,compression,compression1,,1,0,,,${KDBCODE}/processes/compression.q,1,,q
 localhost,{KDBBASEPORT}+14,feed,feed1,,1,0,,,${KDBAPPCODE}/tick/feed.q,1,,q
-localhost,{KDBBASEPORT}+15,chainedtp,chainedtp1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/chainedtp.q,1,,q
+localhost,{KDBBASEPORT}+15,chainedtp,chainedtp1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/chainedtp.q,1,,q
 localhost,{KDBBASEPORT}+16,sortslave,sortslave1,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
 localhost,{KDBBASEPORT}+17,sortslave,sortslave2,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
-localhost,{KDBBASEPORT}+18,metrics,metrics1,${BASEDIR}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/metrics.q,1,,q
+localhost,{KDBBASEPORT}+18,metrics,metrics1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,,,${KDBCODE}/processes/metrics.q,1,,q
 localhost,{KDBBASEPORT}+19,iexfeed,iexfeed1,,1,0,,,${KDBCODE}/processes/iexfeed.q,1,,q

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,7 +1,14 @@
 # if running the kdb+tick example, change these to full paths
 # some of the kdb+tick processes will change directory, and these will no longer be valid
 
-#export TORQHOME=${PWD}
+if [ "-bash" = $0 ]; then
+    dirpath="${BASH_SOURCE[0]}"
+else
+    dirpath="$0"
+fi
+
+export TORQHOME=$(dirname $dirpath)
+export BASEDIR=${TORQHOME}
 export KDBCONFIG=${TORQHOME}/config
 export KDBCODE=${TORQHOME}/code
 export KDBLOG=${TORQHOME}/logs

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,6 +1,7 @@
 # if running the kdb+tick example, change these to full paths
 # some of the kdb+tick processes will change directory, and these will no longer be valid
-export TORQHOME=${PWD}
+
+#export TORQHOME=${PWD}
 export KDBCONFIG=${TORQHOME}/config
 export KDBCODE=${TORQHOME}/code
 export KDBLOG=${TORQHOME}/logs
@@ -24,10 +25,10 @@ export TORQPROCESSES=${KDBAPPCONFIG}/process.csv
 
 touch $KDBLOG/torqsslcert.txt
 if [ -z "${SSL_CA_CERT_FILE}" ]; then
-	mkdir ${PWD}/certs
-	curl -s  https://curl.haxx.se/ca/cacert.pm > ${PWD}/certs/cabundle.pem
-	echo "`date`    The SSL securiity certificate has been downloaded to ${PWD}/certs/cabundle.pem" </dev/null >>$KDBLOG/torqsslcert.txt 
-	export SSL_CA_CERT_FILE=${PWD}/certs/cabundle.pem
+	mkdir ${TORQHOME}/certs
+	curl -s  https://curl.haxx.se/ca/cacert.pm > ${TORQHOME}/certs/cabundle.pem
+	echo "`date`    The SSL securiity certificate has been downloaded to ${TORQHOME}/certs/cabundle.pem" </dev/null >>$KDBLOG/torqsslcert.txt 
+	export SSL_CA_CERT_FILE=${TORQHOME}/certs/cabundle.pem
 else
 	echo "`date`    The SSL security certificate already exists. If https requests fail it may be because of inappropriate certification." </dev/null >>$KDBLOG/torqsslcert.txt 
 fi

--- a/setenv.sh
+++ b/setenv.sh
@@ -8,7 +8,6 @@ else
 fi
 
 export TORQHOME=$(dirname $dirpath)
-export BASEDIR=${TORQHOME}
 export KDBCONFIG=${TORQHOME}/config
 export KDBCODE=${TORQHOME}/code
 export KDBLOG=${TORQHOME}/logs


### PR DESCRIPTION
This will add the basic configuration needed to use monit to monitor TorQ processes on UNIX-like systems. The processes will be read from the process.csv file, started and monitored by monit. The dashboard can be accessed on localhost port 2812 and will include basic information about the TorQ processes. If any of the processes fail to start, monit will try to restart the process and send an alert e-mail which contains information about the service.