### PR TITLE
Add *.q files to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.q linguist-language=q


### PR DESCRIPTION
I have updated `.gitattributes` to allow for q syntax highlighting when viewing this repo on GitHub.