### PR TITLE
qcon flag for torq.sh

### DIFF
--- a/setenv.sh
+++ b/setenv.sh
@@ -20,8 +20,8 @@ export KDBHDB=${TORQHOME}/hdb/database
 export KDBWDB=${TORQHOME}/wdbhdb
 
 # set rlwrap and qcon paths for use in torq.sh qcon flag functions
-export RLWRAP=/usr/bin/rlwrap
-export QCON=/opt/kdb/qcon
+export RLWRAP="rlwrap"
+export QCON="qcon"
 
 # set the application specific configuration directory
 export KDBAPPCONFIG=${TORQHOME}/appconfig

--- a/setenv.sh
+++ b/setenv.sh
@@ -19,6 +19,10 @@ export KDBLIB=${TORQHOME}/lib
 export KDBHDB=${TORQHOME}/hdb/database
 export KDBWDB=${TORQHOME}/wdbhdb
 
+# set rlwrap and qcon paths
+export RLWRAP=QCON=/usr/bin/rlwrap
+export QCON=/opt/kdb/qcon
+
 # set the application specific configuration directory
 export KDBAPPCONFIG=${TORQHOME}/appconfig
 export KDBAPPCODE=${TORQHOME}/code

--- a/setenv.sh
+++ b/setenv.sh
@@ -19,7 +19,7 @@ export KDBLIB=${TORQHOME}/lib
 export KDBHDB=${TORQHOME}/hdb/database
 export KDBWDB=${TORQHOME}/wdbhdb
 
-# set rlwrap and qcon paths
+# set rlwrap and qcon paths for use in torq.sh qcon flag functions
 export RLWRAP=/usr/bin/rlwrap
 export QCON=/opt/kdb/qcon
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -20,7 +20,7 @@ export KDBHDB=${TORQHOME}/hdb/database
 export KDBWDB=${TORQHOME}/wdbhdb
 
 # set rlwrap and qcon paths
-export RLWRAP=QCON=/usr/bin/rlwrap
+export RLWRAP=/usr/bin/rlwrap
 export QCON=/opt/kdb/qcon
 
 # set the application specific configuration directory


### PR DESCRIPTION
# qcon alias! :computer:

### PR general description
Adding qcon flag such that `./torq.sh qcon <processname> <username>:<password>` will connect to the process without need for port to be entered manually. This is implemented within the TorQ repository. To avoid overwriting of needed environment variables RLWRAP and QCON they have been added to setenv.sh in TorQ-Finance-Starter-Pack.

### Final Checklist
- [x] My code follows the code style of this project
- [x] My code is commented appropriately and concisely
- [x] If necessary, I have added new appropriate labels to this PR
- [x] I have assigned the appropriate users to this PR