### PR TITLE
Fix select statement in metrics.q to work with kdb 4

### DIFF
--- a/code/processes/metrics.q
+++ b/code/processes/metrics.q
@@ -13,7 +13,7 @@ enableallday:@[value;`enableallday;1b];
 / define upd to keep running sums
 upd:{[t;x]
    / join latest to x, maintaining time col from x, then calc running sums
-   r:ungroup select time,sym,sumssize:(0^sumssize)+sums size,sumsps:(0^sumsps)+sum price*size,sumspricetimediff:(0^sumspricetimediff)+sums price*0^deltas[first lt;time] by sym from x lj delete time from update lt:time from latest;
+   r:ungroup select time,sumssize:(0^sumssize)+sums size,sumsps:(0^sumsps)+sum price*size,sumspricetimediff:(0^sumspricetimediff)+sums price*0^deltas[first lt;time] by sym from x lj delete time from update lt:time from latest;
    / add latest values for each sym from r to latest
    latest,::select by sym from r;
    / add records to sumstab for all records in update message


### PR DESCRIPTION
Select statement in upd function breaks in kdb 4.0, as it selects a column col 
that is also used in the by clause. Removing the column in the select part of 
the statement leads to the code giving the same result, so is redundant and 
removed, allowing upd function to work in kdb 4.0.
