### PR TITLE
Add config for the symfilegrowth check 

### DIFF
--- a/appconfig/dqcconfig.csv
+++ b/appconfig/dqcconfig.csv
@@ -14,4 +14,4 @@ nullchk,`comp`vars ! (0b; (`quote; `bid`ask; 10)),`rdb1,repeat,09:00:00.00000000
 pctAvgDailyChange,`comp`vars!(0b;(`symcount;`quote;`resultstab;2;0)),`dqedb1,repeat,09:00:00.000000000,0Wn,0D00:02:00
 datechk,`comp`vars!(0b;0N),`hdb1,repeat,00:10:00.000000000,0Wn,0D00:01:00
 dfilechk,`comp`vars!(0b;`trade),`hdb1,repeat,09:00:00.000000000,0Wn,0D00:01:00
-symfilegrowth,(`comp`vars!(0b;(.dqe.hdbdir;2;5))),`dqc1,single,09:05:00.000000000,0N,0N
+symfilegrowth,(`comp`vars!(0b;(.dqe.hdbdir;2;5))),`dqe1,single,09:05:00.000000000,0N,0N

--- a/appconfig/dqcconfig.csv
+++ b/appconfig/dqcconfig.csv
@@ -14,3 +14,4 @@ nullchk,`comp`vars ! (0b; (`quote; `bid`ask; 10)),`rdb1,repeat,09:00:00.00000000
 pctAvgDailyChange,`comp`vars!(0b;(`symcount;`quote;`resultstab;2;0)),`dqedb1,repeat,09:00:00.000000000,0Wn,0D00:02:00
 datechk,`comp`vars!(0b;0N),`hdb1,repeat,00:10:00.000000000,0Wn,0D00:01:00
 dfilechk,`comp`vars!(0b;`trade),`hdb1,repeat,09:00:00.000000000,0Wn,0D00:01:00
+symfilegrowth,(`comp`vars!(0b;(.dqe.hdbdir;2;5))),`dqc1,single,09:05:00.000000000,0N,0N

--- a/appconfig/dqcconfig.csv
+++ b/appconfig/dqcconfig.csv
@@ -14,4 +14,4 @@ nullchk,`comp`vars ! (0b; (`quote; `bid`ask; 10)),`rdb1,repeat,09:00:00.00000000
 pctAvgDailyChange,`comp`vars!(0b;(`symcount;`quote;`resultstab;2;0)),`dqedb1,repeat,09:00:00.000000000,0Wn,0D00:02:00
 datechk,`comp`vars!(0b;0N),`hdb1,repeat,00:10:00.000000000,0Wn,0D00:01:00
 dfilechk,`comp`vars!(0b;`trade),`hdb1,repeat,09:00:00.000000000,0Wn,0D00:01:00
-symfilegrowth,(`comp`vars!(0b;(2;5))),`dqe1,single,09:05:00.000000000,0N,0N
+symfilegrowth,(`comp`vars!(0b;(2;5;0b))),`dqe1,single,09:05:00.000000000,0N,0N

--- a/appconfig/dqcconfig.csv
+++ b/appconfig/dqcconfig.csv
@@ -14,4 +14,4 @@ nullchk,`comp`vars ! (0b; (`quote; `bid`ask; 10)),`rdb1,repeat,09:00:00.00000000
 pctAvgDailyChange,`comp`vars!(0b;(`symcount;`quote;`resultstab;2;0)),`dqedb1,repeat,09:00:00.000000000,0Wn,0D00:02:00
 datechk,`comp`vars!(0b;0N),`hdb1,repeat,00:10:00.000000000,0Wn,0D00:01:00
 dfilechk,`comp`vars!(0b;`trade),`hdb1,repeat,09:00:00.000000000,0Wn,0D00:01:00
-symfilegrowth,(`comp`vars!(0b;(.dqe.hdbdir;2;5))),`dqe1,single,09:05:00.000000000,0N,0N
+symfilegrowth,(`comp`vars!(0b;(2;5))),`dqe1,single,09:05:00.000000000,0N,0N


### PR DESCRIPTION
Add the configuration for the symfile growth checker function being added to TorQ. The default behaviour is an average over the previous two days and a 5% growth limit.