### PR TITLE
Remove colon in dqcconfig that causes refdatacheck not to run

### DIFF
--- a/appconfig/dqcconfig.csv
+++ b/appconfig/dqcconfig.csv
@@ -14,5 +14,5 @@ nullchk,`comp`vars ! (0b; (`quote; `bid`ask; 10)),`rdb1,repeat,09:00:00.00000000
 pctAvgDailyChange,`comp`vars!(0b;(`symcount;`quote;`resultstab;2;0)),`dqedb1,repeat,09:00:00.000000000,0Wn,0D00:02:00
 datechk,`comp`vars!(0b;0N),`hdb1,repeat,00:10:00.000000000,0Wn,0D00:01:00
 dfilechk,`comp`vars!(0b;`trade),`hdb1,repeat,09:00:00.000000000,0Wn,0D00:01:00
-refdatacheck,`comp`vars!(0b;(`trade;`quote;`sym;`sym)),`rdb1,repeat,09:00:00.000000000,0Wn,0D:00:05:00
+refdatacheck,`comp`vars!(0b;(`trade;`quote;`sym;`sym)),`rdb1,repeat,09:00:00.000000000,0Wn,0D00:05:00
 symfilegrowth,(`comp`vars!(0b;(2;5;0b))),`dqe1,single,09:05:00.000000000,0N,0N


### PR DESCRIPTION
The reference data check was not running, as there was an error in the config. 