### PR TITLE
Adding configuration for the two new queries running in the Engine of DQE

### DIFF
--- a/appconfig/dqengineconfig.csv
+++ b/appconfig/dqengineconfig.csv
@@ -6,4 +6,3 @@ infinitycount,(`quote;`ask),`hdb1,table,09:00:00.000000000
 infinitycount,(`quote;`),`hdb1,table,09:00:00.000000000
 nullcount,(`quote;`ask),`hdb1,table,09:00:00.000000000
 nullcount,(`quote;`),`hdb1,table,09:00:00.000000000
-

--- a/appconfig/dqengineconfig.csv
+++ b/appconfig/dqengineconfig.csv
@@ -2,8 +2,8 @@ query,params,proc,querytype,starttime
 tablecount,.z.d-1,`hdb1,table,09:00:00.000000000
 symfilecheck,`sym,`hdb1,other,09:00:00.000000000
 symcount,(`quote;`sym),`hdb1,table,09:00:00.000000000
-infinitycount,(`quote;`sym),`hdb1,table,09:00:00.000000000
+infinitycount,(`quote;`ask),`hdb1,table,09:00:00.000000000
 infinitycount,(`quote;`),`hdb1,table,09:00:00.000000000
-nullcount,(`quote;`sym),`hdb1,table,09:00:00.000000000
+nullcount,(`quote;`ask),`hdb1,table,09:00:00.000000000
 nullcount,(`quote;`),`hdb1,table,09:00:00.000000000
 

--- a/appconfig/dqengineconfig.csv
+++ b/appconfig/dqengineconfig.csv
@@ -2,8 +2,8 @@ query,params,proc,querytype,starttime
 tablecount,.z.d-1,`hdb1,table,09:00:00.000000000
 symfilecheck,`sym,`hdb1,other,09:00:00.000000000
 symcount,(`quote;`sym),`hdb1,table,09:00:00.000000000
-infinitycount,(`quote;`sym),hdb1,table,09:00:00.000000000
-infinitycount,(`quote;`),hdb1,table,09:00:00.000000000
-nullcount,(`quote;`sym),hdb1,table,09:00:00.000000000
-nullcount,(`quote;`),hdb1,table,09:00:00.000000000
+infinitycount,(`quote;`sym),`hdb1,table,09:00:00.000000000
+infinitycount,(`quote;`),`hdb1,table,09:00:00.000000000
+nullcount,(`quote;`sym),`hdb1,table,09:00:00.000000000
+nullcount,(`quote;`),`hdb1,table,09:00:00.000000000
 

--- a/appconfig/dqengineconfig.csv
+++ b/appconfig/dqengineconfig.csv
@@ -2,3 +2,8 @@ query,params,proc,querytype,starttime
 tablecount,.z.d-1,`hdb1,table,09:00:00.000000000
 symfilecheck,`sym,`hdb1,other,09:00:00.000000000
 symcount,(`quote;`sym),`hdb1,table,09:00:00.000000000
+infinitycount,(`quote;`sym),hdb1,table,09:00:00.000000000
+infinitycount,(`quote;`),hdb1,table,09:00:00.000000000
+nullcount,(`quote;`sym),hdb1,table,09:00:00.000000000
+nullcount,(`quote;`),hdb1,table,09:00:00.000000000
+


### PR DESCRIPTION
Nullcount and infinitycount are currently in TorQ PRs
tested out both with this configuration and results are shown as expected.