### PR TITLE
Update terminology to be more inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The web request that goes to the API provided by IEX goes through HTTPS. If the 
 - **1.2.1, September 2016**:
   * REQUIRES TORQ 2.6.2
   * added broadcast functionality to u.q
-  * added sortslave functionality
+  * added sortworker functionality
 - **1.2.0, April 2016**:
   * REQUIRES TORQ 2.5.0
   * Removed u.q

--- a/appconfig/passwords/accesslist.txt
+++ b/appconfig/passwords/accesslist.txt
@@ -12,7 +12,7 @@ sort:pass
 tickerplant:pass
 wdb:pass
 chainedtp:pass
-sortslave:pass
+sortworker:pass
 metrics:pass
 vwapsub:pass
 dqc:pass

--- a/appconfig/process.csv
+++ b/appconfig/process.csv
@@ -14,8 +14,8 @@ localhost,{KDBBASEPORT}+11,housekeeping,housekeeping1,${TORQHOME}/appconfig/pass
 localhost,{KDBBASEPORT}+12,reporter,reporter1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/reporter.q,1,,q
 localhost,{KDBBASEPORT}+14,feed,feed1,,1,0,,,${KDBAPPCODE}/tick/feed.q,1,,q
 localhost,{KDBBASEPORT}+15,chainedtp,chainedtp1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,0,,,${KDBCODE}/processes/chainedtp.q,1,,q
-localhost,{KDBBASEPORT}+16,sortslave,sortslave1,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
-localhost,{KDBBASEPORT}+17,sortslave,sortslave2,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
+localhost,{KDBBASEPORT}+16,sortworker,sortworker1,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
+localhost,{KDBBASEPORT}+17,sortworker,sortworker2,,1,1,,,${KDBCODE}/processes/wdb.q,1,,q
 localhost,{KDBBASEPORT}+18,metrics,metrics1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,,,${KDBAPPCODE}/processes/metrics.q,1,,q
 localhost,{KDBBASEPORT}+19,iexfeed,iexfeed1,,1,0,,,${KDBAPPCODE}/processes/iexfeed.q,1,,q
 localhost,{KDBBASEPORT}+20,dqc,dqc1,${TORQHOME}/appconfig/passwords/accesslist.txt,1,1,,,${KDBAPPCODE}/processes/dqc.q,1,-parentproctype dqcommon,q

--- a/appconfig/settings/monitor.q
+++ b/appconfig/settings/monitor.q
@@ -3,4 +3,4 @@
 \d .servers
 // list of connections to make at start up
 // can't use `ALL as the tickerplant doesn't publish heartbeats
-CONNECTIONS:`discovery`rdb`hdb`wdb`sort`gateway`housekeeping`reporter`feed`sortslave
+CONNECTIONS:`discovery`rdb`hdb`wdb`sort`gateway`housekeeping`reporter`feed`sortworker

--- a/appconfig/settings/sort.q
+++ b/appconfig/settings/sort.q
@@ -6,5 +6,5 @@ hdbdir:hsym`$getenv[`KDBHDB]		// move wdb database to different location
 tickerplanttypes:sorttypes:()		// sort doesn't need these connections
 
 \d .servers
-CONNECTIONS:`hdb`rdb`gateway`sortslave        // list of connections to make at start up
+CONNECTIONS:`hdb`rdb`gateway`sortworker        // list of connections to make at start up
 

--- a/appconfig/settings/wdb.q
+++ b/appconfig/settings/wdb.q
@@ -3,7 +3,7 @@
 \d .wdb
 savedir:hsym `$getenv[`KDBWDB]		// location to save wdb data
 hdbdir:hsym`$getenv[`KDBHDB]            // move wdb database to different location
-sortslavetypes:()			// WDB doesn't need to connect to sortslaves
+sortworkertypes:()			// WDB doesn't need to connect to sortworkers
 
 \d .servers
 CONNECTIONS:`tickerplant`sort`gateway`rdb`hdb

--- a/start_torq_demo.bat
+++ b/start_torq_demo.bat
@@ -59,9 +59,9 @@ start "feed" q torq.q -load code/tick/feed.q -proctype feed -procname feed1 -U a
 REM launch iexfeed
 start "iexfeed" q torq.q -load code/processes/iexfeed.q -proctype iexfeed -procname iexfeed1 -U appconfig/passwords/accesslist.txt -localtime
 
-REM launch sort slave process
-start "sortslave1" q torq.q -load code/processes/wdb.q -proctype sortslave -procname slavesort1 -localtime -g 1 
-start "sortslave2" q torq.q -load code/processes/wdb.q -proctype sortslave -procname slavesort2 -localtime -g 1
+REM launch sort worker process
+start "sortworker1" q torq.q -load code/processes/wdb.q -proctype sortworker -procname workersort1 -localtime -g 1 
+start "sortworker2" q torq.q -load code/processes/wdb.q -proctype sortworker -procname workersort2 -localtime -g 1
 
 REM launch metrics
 start "metrics" q torq.q -load code/processes/metrics.q -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1

--- a/start_torq_demo.sh
+++ b/start_torq_demo.sh
@@ -70,13 +70,13 @@ nohup q torq.q -load code/tick/feed.q ${KDBSTACKID} -proctype feed -procname fee
 echo 'Starting iexfeed...'
 nohup q torq.q -load code/processes/iexfeed.q ${KDBSTACKID} -proctype iexfeed -procname iexfeed1 -localtime </dev/null >$KDBLOG/torqfeed.txt 2>&1 &
 
-# launch sort slave 1
-echo 'Starting sort slave-1...'
-nohup q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortslave -procname sortslave1 -localtime -g 1 </dev/null >$KDBLOG/torqsortslave1.txt 2>&1 &
+# launch sort worker 1
+echo 'Starting sort worker-1...'
+nohup q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker1 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker1.txt 2>&1 &
 
-# launch sort slave 2
-echo 'Starting sort slave-2...'
-nohup q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortslave -procname sortslave2 -localtime -g 1 </dev/null >$KDBLOG/torqsortslave2.txt 2>&1 &
+# launch sort worker 2
+echo 'Starting sort worker-2...'
+nohup q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker2 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker2.txt 2>&1 &
 
 # launch metrics
 echo 'Stating metrics...'

--- a/stop_torq_demo.bat
+++ b/stop_torq_demo.bat
@@ -19,4 +19,4 @@ set KDBBASEPORT=6000
 set PATH=%PATH%;%KDBLIB%\w32
 
 REM to kill it, run this:
-start "kill" q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb tickerplant chainedtp hdb gateway housekeeping monitor discovery sort sortslave reporter compression iexfeed feed metrics
+start "kill" q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb tickerplant chainedtp hdb gateway housekeeping monitor discovery sort sortworker reporter compression iexfeed feed metrics

--- a/stop_torq_demo.sh
+++ b/stop_torq_demo.sh
@@ -5,4 +5,4 @@
 
 #kill all torq procs
 echo 'Shutting down TorQ...'
-q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS sortslave iexfeed feed rdb tickerplant chainedtp hdb gateway housekeeping monitor discovery wdb sort reporter compression metrics </dev/null >$KDBLOG/torqkill.txt 2>&1 &
+q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS sortworker iexfeed feed rdb tickerplant chainedtp hdb gateway housekeeping monitor discovery wdb sort reporter compression metrics </dev/null >$KDBLOG/torqkill.txt 2>&1 &


### PR DESCRIPTION
Update terminology to be more inclusive by renaming sortslave to sortworker. This corresponds to similar changes being made in the [vanilla TorQ repo](https://github.com/AquaQAnalytics/TorQ/pull/300) that this relies on.