### PR TITLE
adding installlatest file to the branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Assuming that the [free 32 bit version of kdb+](http://kx.com/software-download.
 
 1.  Download and install kdb+ from [Kx Systems](http://kx.com)
 
-2.  Download the Install script in the dirctory where you want the TorQ to be installed using:
+2.  Download the install script in the directory where you want the TorQ to be installed using:
 
     `wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/master/installlatest.sh`
     

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ An example production ready market data capture system, using randomly generated
 
 Assuming that the [free 32 bit version of kdb+](http://kx.com/software-download.php) is already set up and available from the command prompt as q, then:
 
-1. Download a zip of the latest version of [TorQ](https://github.com/AquaQAnalytics/TorQ/archive/master.zip)
-2. Download a zip of [this starter pack](https://github.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/archive/master.zip)
-3. Unzip TorQ
-4. Unzip the starter pack over the top (this will replace some files)
-5. Run the appropriate starts script: start_torq_demo.bat for Windows, start_torq_demo_mac.sh for macOS, and torq.sh with the command line argument start all for Linux.
+1.  Download and install kdb+ from [Kx Systems](http://kx.com)
+
+2.  Download the Install script in the dirctory where you want the TorQ to be installed using:
+
+    `wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/master/installlatest.sh`
+    
+3. Run the appropriate starts script: start_torq_demo.bat for Windows, start_torq_demo_mac.sh for macOS, and torq.sh in the bin directory with the command line argument start all for Linux.
 
 For more information on how to configure and get started, go to [this site](https://aquaqanalytics.github.io/TorQ-Finance-Starter-Pack/).  You will need to make some modifications if you wish to send emails from the system.
 

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -21,7 +21,7 @@ Installation and Configuration
 
 1.  Download and install kdb+ from [Kx Systems](http://kx.com)
 
-2.  Download the Install script in the dirctory where you want the TorQ to be installed using:
+2.  Download the install script in the directory where you want the TorQ to be installed using:
 
     `wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/master/installlatest.sh`
     
@@ -280,4 +280,3 @@ Make It Your Own
 The system is production ready. To customize it for a specific data set,
 modify the schema file and replace the feed process with a feed of data
 from a live system.
-

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -21,15 +21,12 @@ Installation and Configuration
 
 1.  Download and install kdb+ from [Kx Systems](http://kx.com)
 
-2.  Download the main TorQ codebase from
-    [here](https://github.com/AquaQAnalytics/TorQ/archive/master.zip)
+2.  Download the Install script in the dirctory where you want the TorQ to be installed using:
 
-3.  Download the TorQ Finance Starter Pack from
-    [here](https://github.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/archive/master.zip)[
-
-4.  Unzip the TorQ package
-
-5.  Unzip the Demo Pack over the top of the main TorQ package
+    `wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/master/installlatest.sh`
+    
+3.  bash installlatest.sh
+    
 
 ### Configuration
 

--- a/installlatest.sh
+++ b/installlatest.sh
@@ -1,0 +1,58 @@
+
+get_latest_release() {
+	curl --silent "https://api.github.com/repos/$1/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'
+}
+
+
+##Change this to correct path after release
+wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ/master/installtorqapp.sh
+
+torq_latest=`get_latest_release "AquaQAnalytics/TorQ"`
+
+echo "============================================================="
+echo "Latest TorQ release"
+echo $torq_latest
+echo "Getting the latest TorQ .tar.gz file"
+echo "============================================================="
+
+wget --content-disposition https://github.com/AquaQAnalytics/TorQ/archive/$torq_latest.tar.gz
+
+echo $torq_latest
+
+if [ "${torq_latest%%v*}" ]
+then
+  echo "tag doesn't start with v"
+else
+  torq_latest=${torq_latest#?}
+fi
+
+
+echo $torq_latest
+
+
+
+torq_fsp_latest=`get_latest_release "AquaQAnalytics/TorQ-Finance-Starter-Pack"`
+
+echo "============================================================="
+echo "Latest TorQ-FSP release"
+echo $torq_fsp_latest
+echo "Getting the latest TorQ-FSP .tar.gz file"
+echo "============================================================="
+
+wget --content-disposition https://github.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/archive/$torq_fsp_latest.tar.gz
+
+echo $torq_fsp_latest
+
+if [ "${torq_fsp_latest%%v*}" ]
+then
+  echo "tag doesn't start with v"
+else
+  torq_fsp_latest=${torq_fsp_latest#?}
+fi
+
+
+echo $torq_fsp_latest
+
+cho "Files downloaded. Executing install script"
+
+sh installtorqapp.sh torq=TorQ-$torq_latest.tar.gz releasedir=deploy data=datatemp installfile=TorQ-Finance-Starter-Pack-$torq_fsp_latest.tar.gz

--- a/installlatest.sh
+++ b/installlatest.sh
@@ -1,19 +1,31 @@
+#!/bin/bash
+
+#example usage:
+#bash installlatest.sh
 
 get_latest_release() {
 	curl --silent "https://api.github.com/repos/$1/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'
 }
 
-
-##Change this to correct path after release
 wget https://raw.githubusercontent.com/AquaQAnalytics/TorQ/master/installtorqapp.sh
 
 torq_latest=`get_latest_release "AquaQAnalytics/TorQ"`
 
-echo "============================================================="
-echo "Latest TorQ release"
-echo $torq_latest
-echo "Getting the latest TorQ .tar.gz file"
-echo "============================================================="
+if [[  $torq_latest == *?.?.? ]] || [[  $torq_latest == *?.??.?? ]];
+then
+        echo "============================================================="
+	echo "Latest TorQ release"
+	echo $torq_latest
+	echo "Getting the latest TorQ .tar.gz file"
+	echo "============================================================="
+
+	
+else
+	echo "the tag for Torq release: "
+        echo $torq_latest
+        echo "Is not in the right format, exiting script."
+	exit 1
+fi
 
 wget --content-disposition https://github.com/AquaQAnalytics/TorQ/archive/$torq_latest.tar.gz
 
@@ -26,10 +38,7 @@ else
   torq_latest=${torq_latest#?}
 fi
 
-
 echo $torq_latest
-
-
 
 torq_fsp_latest=`get_latest_release "AquaQAnalytics/TorQ-Finance-Starter-Pack"`
 
@@ -38,6 +47,23 @@ echo "Latest TorQ-FSP release"
 echo $torq_fsp_latest
 echo "Getting the latest TorQ-FSP .tar.gz file"
 echo "============================================================="
+
+if [[  $torq_fsp_latest == *?.?.? ]] || [[  $torq_fsp_latest == *?.??.?? ]];
+then
+	echo "============================================================="
+	echo "Latest TorQ-FSP release"
+	echo $torq_fsp_latest
+	echo "Getting the latest TorQ-FSP .tar.gz file"
+	echo "============================================================="
+
+	
+else
+        echo "the tag for Torq release: "
+        echo $torq_fsp_latest
+        echo "Is not in the right format, exiting script."
+	exit 1
+fi
+
 
 wget --content-disposition https://github.com/AquaQAnalytics/TorQ-Finance-Starter-Pack/archive/$torq_fsp_latest.tar.gz
 
@@ -50,9 +76,8 @@ else
   torq_fsp_latest=${torq_fsp_latest#?}
 fi
 
-
 echo $torq_fsp_latest
 
-cho "Files downloaded. Executing install script"
+echo "Files downloaded. Executing install script"
 
-sh installtorqapp.sh torq=TorQ-$torq_latest.tar.gz releasedir=deploy data=datatemp installfile=TorQ-Finance-Starter-Pack-$torq_fsp_latest.tar.gz
+bash installtorqapp.sh --torq TorQ-$torq_latest.tar.gz --releasedir deploy --data datatemp --installfile TorQ-Finance-Starter-Pack-$torq_fsp_latest.tar.gz


### PR DESCRIPTION
Install script that automatically pulls the latest version of TorQ and TorQ-FSP from the github 
and installs it on the server. 
User can manually modify the paths in the end of the script. Or can include further functionality to it in future stage to have parameters as the other install script. 

Perhaps as it is basic the data folder line in the end should be removed, so it would just create the data folder in the correct directory. 

Put will have a look at that then next week. 

Right now the link to installscript doesn't work it is pointing to master, but there is nothing there. Needs to be tested after TorQ installscript branch has been merged with master. 