### PR TITLE
Make feed data more random 

### DIFF
--- a/code/tick/feed.q
+++ b/code/tick/feed.q
@@ -35,7 +35,6 @@ randomize[]
 
 / =========================================================================================
 / generate weights to stop even distribution of counts and sizes
-
 weight:0.1*neg[cnt]?2*cnt
 
 / assign multipliers to skew size columns
@@ -44,13 +43,13 @@ bidmap:s!neg[cnt]?weight
 askmap:s!neg[cnt]?weight
 
 / returns list where count of each item is given by random permutation of integer weights
-skewitems:{[weights;items] raze weights#'neg[count items]?items}
+skewitems:{[weights;items]raze weights#'neg[count items]?items}
 
 / skew sym counts with weighted list of indices
 weightedsyms:skewitems[`long$weight*10;til cnt]
 
 / assign skewed side and src lists to determine probabilities of appearing
-sideweight:cnt?{x,cnt-x}'[1+til `int$-1+cnt%2]
+sideweight:cnt?{x,cnt-x}'[1+til cnt-1]
 sidemap:s!skewitems[;side] each sideweight
 srcweight:1+til count src
 srcmap:s!skewitems[srcweight;] each cnt#enlist src

--- a/code/tick/feed.q
+++ b/code/tick/feed.q
@@ -35,7 +35,7 @@ randomize[]
 
 / =========================================================================================
 / generate weights to stop even distribution of counts and sizes
-weight:0.1*neg[cnt]?2*cnt
+weight:0.1*1+neg[cnt]?2*cnt
 
 / assign multipliers to skew size columns
 volmap:s!neg[cnt]?weight

--- a/code/tick/feed.q
+++ b/code/tick/feed.q
@@ -34,29 +34,29 @@ vol:{10+`int$x?90}
 randomize[]
 / \S 235721
 
-/ ================================================================================
+/ =========================================================================================
 / generate weights to stop even distribution of counts and sizes
 
-wght:0.3 0.6 1.8 1.1 1.2 1.6 0.9 0.4 0.7 1.4
+weight:0.3 0.6 1.8 1.1 1.2 1.6 0.9 0.4 0.7 1.4
 
 / assign multipliers to skew size columns
-volmap:s!-10?wght
-bidmap:s!-10?wght
-askmap:s!-10?wght
+volmap:s!-10?weight
+bidmap:s!-10?weight
+askmap:s!-10?weight
 
-/ returns list where count of each item is given by random permutation of weights
-skewitems:{[wghts;items] raze (#) .' wghts,' neg[count items]?items}
+/ returns list where count of each item is given by random permutation of integer weights
+skewitems:{[weights;items] raze (#) .' weights,' neg[count items]?items}
 
 / skew sym counts with weighted list of indices
-weightedsyms:skewitems[`long$wght*10;til cnt] / 100 weighted indices when cnt=10
+weightedsyms:skewitems[`long$weight*10;til cnt] / 100 weighted indices when cnt=10
 
 / assign skewed side and src lists to determine probabilities of appearing
-sidewght:cnt?{x,cnt-x}'[1+til 4]
-sidemap:s!skewitems[;side] each sidewght
-srcwght:1 2 3 4
-srcmap:s!skewitems[srcwght;] each cnt#enlist src
+sideweight:cnt?{x,cnt-x}'[1+til 4]
+sidemap:s!skewitems[;side] each sideweight
+srcweight:1 2 3 4
+srcmap:s!skewitems[srcweight;] each cnt#enlist src
 
-/ ================================================================================
+/ =========================================================================================
 / generate a batch of prices
 / qx index, qb/qa margins, qp price, qn position
 batch:{
@@ -78,7 +78,7 @@ batch len
 maxn:15 / max trades per tick
 qpt:5   / avg quotes per trade
 
-/ ================================================================================
+/ =========================================================================================
 t:{
  if[not (qn+x)<count qx;batch len];
  i:qx n:qn+til x;qn+:x;

--- a/code/tick/feed.q
+++ b/code/tick/feed.q
@@ -32,28 +32,27 @@ rnd:{0.01*floor 0.5+x*100}
 vol:{10+`int$x?90}
 
 randomize[]
-/ \S 235721
 
 / =========================================================================================
 / generate weights to stop even distribution of counts and sizes
 
-weight:0.3 0.6 1.8 1.1 1.2 1.6 0.9 0.4 0.7 1.4
+weight:0.1*neg[cnt]?2*cnt
 
 / assign multipliers to skew size columns
-volmap:s!-10?weight
-bidmap:s!-10?weight
-askmap:s!-10?weight
+volmap:s!neg[cnt]?weight
+bidmap:s!neg[cnt]?weight
+askmap:s!neg[cnt]?weight
 
 / returns list where count of each item is given by random permutation of integer weights
-skewitems:{[weights;items] raze (#) .' weights,' neg[count items]?items}
+skewitems:{[weights;items] raze weights#'neg[count items]?items}
 
 / skew sym counts with weighted list of indices
-weightedsyms:skewitems[`long$weight*10;til cnt] / 100 weighted indices when cnt=10
+weightedsyms:skewitems[`long$weight*10;til cnt]
 
 / assign skewed side and src lists to determine probabilities of appearing
-sideweight:cnt?{x,cnt-x}'[1+til 4]
+sideweight:cnt?{x,cnt-x}'[1+til `int$-1+cnt%2]
 sidemap:s!skewitems[;side] each sideweight
-srcweight:1 2 3 4
+srcweight:1+til count src
 srcmap:s!skewitems[srcweight;] each cnt#enlist src
 
 / =========================================================================================

--- a/code/tick/feed.q
+++ b/code/tick/feed.q
@@ -34,12 +34,28 @@ vol:{10+`int$x?90}
 / randomize[]
 \S 235721
 
+/ ========================================================
+/ generate weights
+
+wght:0.03 0.06 0.18 0.11 0.12 0.16 0.09 0.04 0.07 0.14 / sum to 1
+volwght:s!-10?wght*10
+bidwght:s!-10?wght*10
+askwght:s!-10?wght*10
+
+weightedlist:{[wghts;items] raze (#) .' wghts,' neg[count items]?items}
+
+sidewght:raze 2#enlist {x,10-x}'[1+til 5]
+sidemap:s!weightedlist[;`buy`sell] each sidewght
+
+srcwght:1 2 3 4
+srcmap:s!weightedlist[srcwght;] each cnt#enlist src
+
 / =========================================================
 / generate a batch of prices
 / qx index, qb/qa margins, qp price, qn position
 batch:{
  d:gen x;
- qx::x?cnt;
+ qx::x?weightedlist[`int$wght*x;til cnt];
  qb::rnd x?1.0;
  qa::rnd x?1.0;
  n:where each qx=/:til cnt;
@@ -60,12 +76,12 @@ qpt:5   / avg quotes per trade
 t:{
  if[not (qn+x)<count qx;batch len];
  i:qx n:qn+til x;qn+:x;
- (s i;qp n;`int$x?99;1=x?20;x?c;e i;x?side)}
+ (s i;qp n;`int$volwght[s i]*x?99;1=x?20;x?c;e i;raze 1?'sidemap[s i])}
 
 q:{
  if[not (qn+x)<count qx;batch len];
  i:qx n:qn+til x;p:qp n;qn+:x;
- (s i;p-qb n;p+qa n;`long$vol x;`long$vol x;x?m;e i;x?src)}
+ (s i;p-qb n;p+qa n;`long$bidwght[s i]*vol x;`long$askwght[s i]*vol x;x?m;e i;raze 1?'srcmap[s i])}
 
 feed:{h$[rand 2;
  (".u.upd";`trade;t 1+rand maxn);


### PR DESCRIPTION
Adds weightings to feed to stop all sym counts, bid/ask volumes, and trade volumes being the same.

Weightings will change each time the feed is bounced.   