### PR TITLE
Add segmented tickerplant to metrics process, windows and mac start and stop scripts 

### DIFF
--- a/appconfig/settings/metrics.q
+++ b/appconfig/settings/metrics.q
@@ -2,3 +2,4 @@
 \d .metrics
 windows:0D00:01 0D00:05 0D01:00;	/ 1 minute, 5 minute, 1 hour windows
 enableallday:1b;			/ enable all day window by default
+tickerplanttype:`segmentedtickerplant;	/ type of tickerplant to connect to

--- a/code/processes/metrics.q
+++ b/code/processes/metrics.q
@@ -49,12 +49,12 @@ endofday:{[dt;data] .lg.o[`endofday;"Received endofday for ",string dt]};
 
 / check for TP connection
 notpconnected:{[]
-	0 = count select from .sub.SUBSCRIPTIONS where proctype in ((),`segmentedtickerplant), active}
+	0 = count select from .sub.SUBSCRIPTIONS where proctype in ((),.metrics.tickerplanttype), active}
 
 / get handle for TP & subscribe
 subscribe:{
   / get handle
-  if[count s:.sub.getsubscriptionhandles[`tickerplant;();()!()];
+  if[count s:.sub.getsubscriptionhandles[.metrics.tickerplanttype;();()!()];
   subproc:first s;
   / if got handle successfully, subsribe to trade table
   .lg.o[`subscribe;"subscribing to ", string subproc`procname];
@@ -96,7 +96,7 @@ init:{
 \d .
 
 / get connections to TP, & RDB for recovery
-.servers.CONNECTIONS:`rdb`tickerplant;
+.servers.CONNECTIONS:`rdb,.metrics.tickerplanttype;
 .servers.startup[];
 / run the initialisation function to get subscribed & recover
 .metrics.init[];

--- a/start_torq_demo.bat
+++ b/start_torq_demo.bat
@@ -29,7 +29,7 @@ timeout 2
 REM launch the tickerplant, rdb, hdb
 start "segmentedtickerplant" q torq.q -load code/processes/segmentedtickerplant.q -schemafile database.q -tplogdir %KDBTPLOG% -proctype segmentedtickerplant -procname stp1 -U appconfig/passwords/accesslist.txt -localtime
 start "rdb" q torq.q -load code/processes/rdb.q -proctype rdb -procname rdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -T 180
-start "segmentedchainedtickerplant" q torq.q -load code/processes/segmentedtickerplannt.q -proctype sctp -procname sctp1 -U appconfig/passwords/accesslist.txt -localtime -parentproctype segmentedtickerplant
+start "segmentedchainedtickerplant" q torq.q -load code/processes/segmentedtickerplannt.q -proctype segmentedchainedtickerplant -procname sctp1 -U appconfig/passwords/accesslist.txt -localtime -parentproctype segmentedtickerplant
 start "hdb1" q torq.q -load %KDBHDB% -proctype hdb -procname hdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -w 4000
 start "hdb2" q torq.q -load %KDBHDB% -proctype hdb -procname hdb2 -U appconfig/passwords/accesslist.txt -localtime -g 1 -w 4000
 

--- a/start_torq_demo.bat
+++ b/start_torq_demo.bat
@@ -29,7 +29,7 @@ timeout 2
 REM launch the tickerplant, rdb, hdb
 start "segmentedtickerplant" q torq.q -load code/processes/segmentedtickerplant.q -schemafile database.q -tplogdir %KDBTPLOG% -proctype segmentedtickerplant -procname stp1 -U appconfig/passwords/accesslist.txt -localtime
 start "rdb" q torq.q -load code/processes/rdb.q -proctype rdb -procname rdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -T 180
-start "segmentedchainedtickerplant" q torq.q -load code/processes/segmentedtickerplannt.q -proctype segmentedchainedtickerplant -procname sctp1 -U appconfig/passwords/accesslist.txt -localtime -parentproctype segmentedtickerplant
+start "segmentedchainedtp" q torq.q -load code/processes/segmentedtickerplannt.q -proctype segmentedchainedtickerplant -procname sctp1 -U appconfig/passwords/accesslist.txt -localtime -parentproctype segmentedtickerplant
 start "hdb1" q torq.q -load %KDBHDB% -proctype hdb -procname hdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -w 4000
 start "hdb2" q torq.q -load %KDBHDB% -proctype hdb -procname hdb2 -U appconfig/passwords/accesslist.txt -localtime -g 1 -w 4000
 

--- a/start_torq_demo.bat
+++ b/start_torq_demo.bat
@@ -27,9 +27,9 @@ start "discovery" q torq.q -load code/processes/discovery.q -proctype discovery 
 timeout 2
 
 REM launch the tickerplant, rdb, hdb
-start "tickerplant" q torq.q -load code/processes/tickerplant.q -schemafile database -tplogdir %KDBTPLOG% -proctype tickerplant -procname tickerplant1 -U appconfig/passwords/accesslist.txt -localtime 
+start "segmentedtickerplant" q torq.q -load code/processes/segmentedtickerplant.q -schemafile database.q -tplogdir %KDBTPLOG% -proctype segmentedtickerplant -procname stp1 -U appconfig/passwords/accesslist.txt -localtime
 start "rdb" q torq.q -load code/processes/rdb.q -proctype rdb -procname rdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -T 180
-start "chainedtp" q torq.q -load code/processes/chainedtp.q -proctype chainedtp -procname chainedtp1 -U appconfig/passwords/accesslist.txt -localtime
+start "segmentedchainedtickerplant" q torq.q -load code/processes/segmentedtickerplannt.q -proctype sctp -procname sctp1 -U appconfig/passwords/accesslist.txt -localtime -parentproctype segmentedtickerplant
 start "hdb1" q torq.q -load %KDBHDB% -proctype hdb -procname hdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -w 4000
 start "hdb2" q torq.q -load %KDBHDB% -proctype hdb -procname hdb2 -U appconfig/passwords/accesslist.txt -localtime -g 1 -w 4000
 
@@ -67,4 +67,4 @@ REM launch metrics
 start "metrics" q torq.q -load code/processes/metrics.q -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1
 
 REM to kill it, run this:
-REM q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb tickerplant hdb gateway housekeeping monitor discovery sort reporter compression feed -localtime 
+REM q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb segmentedtickerplant segmentedchainedtickerplant hdb gateway housekeeping monitor discovery sort reporter compression feed -localtime

--- a/start_torq_demo.bat
+++ b/start_torq_demo.bat
@@ -67,4 +67,4 @@ REM launch metrics
 start "metrics" q torq.q -load code/processes/metrics.q -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1
 
 REM to kill it, run this:
-REM q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb segmentedtickerplant segmentedchainedtickerplant hdb gateway housekeeping monitor discovery sort reporter compression feed -localtime
+REM q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb segmentedtickerplant segmentedchainedtickerplant hdb gateway housekeeping monitor discovery sort reporter compression feed sortworker iexfeed metrics -localtime

--- a/start_torq_demo.bat
+++ b/start_torq_demo.bat
@@ -60,8 +60,8 @@ REM launch iexfeed
 start "iexfeed" q torq.q -load code/processes/iexfeed.q -proctype iexfeed -procname iexfeed1 -U appconfig/passwords/accesslist.txt -localtime
 
 REM launch sort worker process
-start "sortworker1" q torq.q -load code/processes/wdb.q -proctype sortworker -procname workersort1 -localtime -g 1 
-start "sortworker2" q torq.q -load code/processes/wdb.q -proctype sortworker -procname workersort2 -localtime -g 1
+start "sortworker1" q torq.q -load code/processes/wdb.q -proctype sortworker -procname sortworker1 -localtime -g 1
+start "sortworker2" q torq.q -load code/processes/wdb.q -proctype sortworker -procname sortworker2 -localtime -g 1
 
 REM launch metrics
 start "metrics" q torq.q -load code/processes/metrics.q -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1

--- a/start_torq_demo_mac.sh
+++ b/start_torq_demo_mac.sh
@@ -69,9 +69,9 @@ q torq.q -load code/processes/iexfeed.q ${KDBSTACKID} -proctype iexfeed -procnam
 
 # launch sort worker processes
 echo 'Starting sortworker1...'
-q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker1 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker1.txt 2>&1 & # sortworker1 process
+q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker1 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker1.txt 2>&1 &
 echo 'Starting sortworker2...'
-q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker2 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker2.txt 2>&1 & # sortworker2 process
+q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker2 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker2.txt 2>&1 &
 
 # launch metrics
 q torq.q -load code/processes/metrics.q ${KDBSTACKID} -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1 </dev/null >$KDBLOG/torqcompress1.txt 2>&1 &  # compression process

--- a/start_torq_demo_mac.sh
+++ b/start_torq_demo_mac.sh
@@ -67,5 +67,11 @@ q torq.q -load code/tick/feed.q ${KDBSTACKID} -proctype feed -procname feed1 -lo
 echo 'Starting iexfeed...'
 q torq.q -load code/processes/iexfeed.q ${KDBSTACKID} -proctype iexfeed -procname iexfeed1 -localtime </dev/null >$KDBLOG/torqfeed.txt 2>&1 &
 
+# launch sort worker processes
+echo 'Starting sortworker1...'
+q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker1 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker1.txt 2>&1 & # sortworker1 process
+echo 'Starting sortworker2...'
+q torq.q -load code/processes/wdb.q ${KDBSTACKID} -proctype sortworker -procname sortworker2 -localtime -g 1 </dev/null >$KDBLOG/torqsortworker2.txt 2>&1 & # sortworker2 process
+
 # launch metrics
 q torq.q -load code/processes/metrics.q ${KDBSTACKID} -proctype metrics -procname metrics1 -U appconfig/passwords/accesslist.txt -localtime -g 1 </dev/null >$KDBLOG/torqcompress1.txt 2>&1 &  # compression process

--- a/start_torq_demo_mac.sh
+++ b/start_torq_demo_mac.sh
@@ -17,14 +17,14 @@ echo 'Starting discovery proc...'
 q torq.q -load code/processes/discovery.q ${KDBSTACKID} -proctype discovery -procname discovery1 -U appconfig/passwords/accesslist.txt -localtime </dev/null >$KDBLOG/torqdiscovery.txt 2>&1 &
 
 # launch the tickerplant, rdb, ctp, hdb
-echo 'Starting tp...'
-q torq.q -load code/processes/tickerplant.q -schemafile database -tplogdir ${KDBTPLOG} ${KDBSTACKID} -proctype tickerplant -procname tickerplant1 -U appconfig/passwords/accesslist.txt -localtime </dev/null >$KDBLOG/torqtp.txt 2>&1 &
+echo 'Starting segmentedtp...'
+q torq.q -load code/processes/segmentedtickerplant.q -schemafile database.q -tplogdir ${KDBTPLOG} ${KDBSTACKID} -proctype segmentedtickerplant -procname stp1 -U appconfig/passwords/accesslist.txt -localtime </dev/null >$KDBLOG/torqtp.txt 2>&1 &
 
 echo 'Starting rdb...'
 q torq.q -load code/processes/rdb.q ${KDBSTACKID} -proctype rdb -procname rdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -T 180 </dev/null >$KDBLOG/torqrdb.txt 2>&1 &
 
-echo 'Starting ctp...'
-q torq.q -load code/processes/chainedtp.q ${KDBSTACKID} -proctype chainedtp -procname chainedtp1 -U appconfig/passwords/accesslist.txt -localtime </dev/null >$KDBLOG/torqchainedtp.txt 2>&1 &
+echo 'Starting segmentedctp...'
+q torq.q -load code/processes/segmentedtickerplant.q ${KDBSTACKID} -proctype segmentedchainedtickerplant -procname sctp1 -U appconfig/passwords/accesslist.txt -localtime -parentproctype segmentedtickerplant </dev/null >$KDBLOG/torqchainedtp.txt 2>&1 &
 
 echo 'Starting hdb1...'
 q torq.q -load ${KDBHDB} ${KDBSTACKID} -proctype hdb -procname hdb1 -U appconfig/passwords/accesslist.txt -localtime -g 1 -T 60 -w 4000 </dev/null >$KDBLOG/torqhdb1.txt 2>&1 &

--- a/stop_torq_demo.bat
+++ b/stop_torq_demo.bat
@@ -19,4 +19,4 @@ set KDBBASEPORT=6000
 set PATH=%PATH%;%KDBLIB%\w32
 
 REM to kill it, run this:
-start "kill" q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb tickerplant chainedtp hdb gateway housekeeping monitor discovery sort sortworker reporter compression iexfeed feed metrics
+start "kill" q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS rdb wdb segmentedtickerplant segmentedchainedtickerplant hdb gateway housekeeping monitor discovery sort sortworker reporter compression iexfeed feed metrics

--- a/stop_torq_demo_mac.sh
+++ b/stop_torq_demo_mac.sh
@@ -5,4 +5,4 @@
 
 #kill all torq procs
 echo 'Shutting down TorQ...'
-q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS sortworker iexfeed feed rdb tickerplant chainedtp hdb gateway housekeeping monitor discovery wdb sort reporter compression metrics </dev/null >$KDBLOG/torqkill.txt 2>&1 &
+q torq.q -load code/processes/kill.q -proctype kill -procname killtick -.servers.CONNECTIONS sortworker iexfeed feed rdb segmentedtickerplant segmentedchainedtickerplant hdb gateway housekeeping monitor discovery wdb sort reporter compression metrics </dev/null >$KDBLOG/torqkill.txt 2>&1 &


### PR DESCRIPTION
- Replace old tickerplant with segmented in metrics process, start and stop scripts for mac and windows
- Fix sortworker lines in windows start up script and add sortworker procs to mac start up