### PR TITLE
TCS-131 Update .ds.stripe to sum ASCII codes instead of using md5

### DIFF
--- a/appconfig/settings/default.q
+++ b/appconfig/settings/default.q
@@ -1,1 +1,3 @@
-system"c 23 2000"
+system"c 23 2000";
+// For use with default TorQCloud environment
+.ds.numseg:2i;

--- a/appconfig/striping.json
+++ b/appconfig/striping.json
@@ -2,8 +2,8 @@
     "1": [
         {
             "subscriptiondefault": "all" ,
-            "trade": "sym like \"[A-D]*\"" ,
-            "quote": "sym like \"[A-D]*\""
+            "trade": ".ds.stripe[sym;0]" ,
+            "quote": ".ds.stripe[sym;0]"
 
         }
     ],
@@ -11,8 +11,8 @@
     "2": [
         {
             "subscriptiondefault": "ignore" ,
-            "trade": "sym like \"[E-Z]*\"" ,
-            "quote": "sym like \"[E-Z]*\""
+            "trade": ".ds.stripe[sym;1]" ,
+            "quote": ".ds.stripe[sym;1]"
 
         }
     ]


### PR DESCRIPTION
FSP counterpart to [TorQ PR #478](https://github.com/AquaQAnalytics/TorQ/pull/478).
Have .ds.stripe be used as the default segmenting scheme in a TorQCloud setup.
Also have .ds.numseg be set to 2i initially instead of requiring user to manually change appconfig/settings/default.q.