### PR TITLE
TCS-134 .ds.numseg should use number of segments defined in striping.json

### DIFF
--- a/appconfig/settings/default.q
+++ b/appconfig/settings/default.q
@@ -1,3 +1,3 @@
 system"c 23 2000";
 // For use with default TorQCloud environment
-.ds.numseg:2i;
+.ds.numseg:`int$count key .j.k raze read0 first .proc.getconfigfile["striping.json"]; // numseg based on number of segments defined in striping.json


### PR DESCRIPTION
Removes hardcoded .ds.numseg value and replaces with code to identify the number of segments defined in striping.json