### PR TITLE
Failing merge using sortworkers fix

### DIFF
--- a/appconfig/settings/sort.q
+++ b/appconfig/settings/sort.q
@@ -4,6 +4,7 @@
 savedir:hsym `$getenv[`KDBWDB]          // location to save wdb data
 hdbdir:hsym`$getenv[`KDBHDB]		// move wdb database to different location
 tickerplanttypes:sorttypes:()		// sort doesn't need these connections
+sortworkertypes:enlist `sortworker;     // overwrite empty list
 
 \d .servers
 CONNECTIONS:`hdb`rdb`gateway`sortworker        // list of connections to make at start up

--- a/appconfig/settings/sort.q
+++ b/appconfig/settings/sort.q
@@ -4,7 +4,7 @@
 savedir:hsym `$getenv[`KDBWDB]          // location to save wdb data
 hdbdir:hsym`$getenv[`KDBHDB]		// move wdb database to different location
 tickerplanttypes:sorttypes:()		// sort doesn't need these connections
-sortworkertypes:enlist `sortworker;     // overwrite empty list
+sortworkertypes:enlist `sortworker;     // sort should use sortworkers by default
 
 \d .servers
 CONNECTIONS:`hdb`rdb`gateway`sortworker        // list of connections to make at start up


### PR DESCRIPTION
Cause: sortworkertypes is set to an empty list in wdb config

Fix: Overwrite sortworkertypes in sort process config