### PR TITLE
Update discovery for kdb-x community issue

### DIFF
--- a/appconfig/settings/segmentedchainedtickerplant.q
+++ b/appconfig/settings/segmentedchainedtickerplant.q
@@ -34,4 +34,4 @@ enabled:1b;                     // enable timer
 enabled:1b                      // switch on subscribercutoff
 
 \d .servers
-CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;$[0W=.Q.lim[][`conns];1b;0b];1b] // check for limit on process connections (relevant for KDB-X community edition)
+CONNECTIONSFROMDISCOVERY:$[`lim in key`.Q;@[{$[0W=x[`conns][`lim];1b;0b]};.Q.lim[];1b];1b] // check for limit on process connections (relevant for KDB-X community edition; error-trapped for Community edition where .Q.lim[] may not return expected dict)


### PR DESCRIPTION
.Q.lim[] returns a different dictionary in KDB-X community edition than the full edition.

KDB-X:
q).Q.lim[]
cores  | 0W
threads| 0W
mem    | 0W
conns  | 0W

KDB-X Community:
q).Q.lim[]
       | cur lim
-----  | ---------
cores  | 14  0W
threads| 0   4
mem    | 64  16384
conns  | 0   16

The current index to `conns returns a type error as it compares 0W to a dictionary. Indexing into `lim is required and the conditional is error trapped for attempting to index into .Q.lim for the full version. 